### PR TITLE
Edited docker build task to run only when called

### DIFF
--- a/org-code-javabuilder/app/build.gradle
+++ b/org-code-javabuilder/app/build.gradle
@@ -54,7 +54,7 @@ task installGitHook(type: Copy) {
   fileMode 0777
 }
 
-task buildDocker(type: Copy) {
+def buildDocker = tasks.register('buildDocker', Copy) {
   dependsOn build
   from file("$buildDir/libs")
   into file("$rootDir/dockerContainer")


### PR DESCRIPTION
Edited docker build task to run only when called rather than every time bootRun is called.

The buildDocker task was set up as a "run every time" task. This changes it to only run when `gradle buildDocker` is called