### PR TITLE
Javabuilder: Load java files from main.json

### DIFF
--- a/org-code-javabuilder/lib/build.gradle
+++ b/org-code-javabuilder/lib/build.gradle
@@ -35,8 +35,8 @@ task packageSmall(type: Zip) {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 build.dependsOn packageSmall

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
@@ -11,9 +11,7 @@ public class LocalMain {
   public static void main(String[] args) {
     final LocalInputAdapter inputAdapter = new LocalInputAdapter();
     final LocalOutputAdapter outputAdapter = new LocalOutputAdapter(System.out);
-    // replace with your testing url.
-    String url = "http://localhost-studio.code.org:3000/v3/sources/2sZQjPkr7-vE6zRhbEGTPg";
-    final UserProjectFileManager fileManager = new UserProjectFileManager(url);
+    final LocalProjectFileManager fileManager = new LocalProjectFileManager();
     // Create and invoke the code execution environment
     try (CodeBuilder codeBuilder = new CodeBuilder(inputAdapter, outputAdapter, fileManager)) {
       codeBuilder.compileUserCode();

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
@@ -1,9 +1,6 @@
 package dev.javabuilder;
 
-import org.code.javabuilder.CodeBuilder;
-import org.code.javabuilder.InternalFacingException;
-import org.code.javabuilder.UserFacingException;
-import org.code.javabuilder.UserInitiatedException;
+import org.code.javabuilder.*;
 
 /**
  * Intended for local testing only. This is a local version of the Javabuilder lambda function. The
@@ -14,7 +11,9 @@ public class LocalMain {
   public static void main(String[] args) {
     final LocalInputAdapter inputAdapter = new LocalInputAdapter();
     final LocalOutputAdapter outputAdapter = new LocalOutputAdapter(System.out);
-    final LocalProjectFileManager fileManager = new LocalProjectFileManager();
+    // replace with your testing url.
+    String url = "http://localhost-studio.code.org:3000/v3/sources/2sZQjPkr7-vE6zRhbEGTPg";
+    final UserProjectFileManager fileManager = new UserProjectFileManager(url);
     // Create and invoke the code execution environment
     try (CodeBuilder codeBuilder = new CodeBuilder(inputAdapter, outputAdapter, fileManager)) {
       codeBuilder.compileUserCode();

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -33,7 +33,6 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     final String apiEndpoint = lambdaInput.get("apiEndpoint");
     final String queueUrl = lambdaInput.get("queueUrl");
     final String projectUrl = lambdaInput.get("projectUrl");
-    final String[] fileNames = lambdaInput.get("fileNames").split(",");
 
     // Create user-program output handlers
     AmazonApiGatewayManagementApi api =
@@ -48,8 +47,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     final AWSInputAdapter inputAdapter = new AWSInputAdapter(sqsClient, queueUrl);
 
     // Create file manager
-    final UserProjectFileManager userProjectFileManager =
-        new UserProjectFileManager(projectUrl, fileNames);
+    final UserProjectFileManager userProjectFileManager = new UserProjectFileManager(projectUrl);
 
     // Create and invoke the code execution environment
     try (CodeBuilder codeBuilder =

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ProjectFile.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ProjectFile.java
@@ -15,6 +15,11 @@ public class ProjectFile {
     }
   }
 
+  public ProjectFile(String fileName, String code) throws UserInitiatedException {
+    this(fileName);
+    this.code = code;
+  }
+
   public String getFileName() {
     return fileName;
   }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserFileData.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserFileData.java
@@ -1,0 +1,25 @@
+package org.code.javabuilder;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserFileData {
+  private String text;
+  private boolean visible;
+
+  public String getText() {
+    return this.text;
+  }
+
+  public boolean getVisible() {
+    return this.visible;
+  }
+
+  public void setText(String text) {
+    this.text = text;
+  }
+
+  public void setVisible(boolean visible) {
+    this.visible = visible;
+  }
+}

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserProjectFileParser.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserProjectFileParser.java
@@ -1,0 +1,39 @@
+package org.code.javabuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class UserProjectFileParser {
+  private final ObjectMapper objectMapper;
+
+  public UserProjectFileParser() {
+    this.objectMapper = new ObjectMapper();
+  }
+
+  /**
+   * Parses json string containing file data and stores it in this.fileList.
+   *
+   * @param json JSON String in UserSourceData format
+   * @throws UserFacingException
+   * @throws UserInitiatedException
+   */
+  public List<ProjectFile> parseFileJson(String json)
+      throws UserFacingException, UserInitiatedException {
+    List<ProjectFile> fileList = new ArrayList<ProjectFile>();
+    try {
+      UserSourceData sourceData = this.objectMapper.readValue(json, UserSourceData.class);
+      Map<String, UserFileData> sources = sourceData.getSource();
+      for (String fileName : sources.keySet()) {
+        UserFileData fileData = sources.get(fileName);
+        fileList.add(new ProjectFile(fileName, fileData.getText()));
+      }
+    } catch (IOException io) {
+      throw new UserFacingException(
+          "We hit an error trying to load your files. Please try again.\n", io);
+    }
+    return fileList;
+  }
+}

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserProjectFileParser.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserProjectFileParser.java
@@ -14,9 +14,10 @@ public class UserProjectFileParser {
   }
 
   /**
-   * Parses json string containing file data and stores it in this.fileList.
+   * Parses json string containing file data and returns a list of project files.
    *
    * @param json JSON String in UserSourceData format
+   * @return a list of ProjectFile objects
    * @throws UserFacingException
    * @throws UserInitiatedException
    */

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserSourceData.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserSourceData.java
@@ -1,0 +1,17 @@
+package org.code.javabuilder;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserSourceData {
+  private Map<String, UserFileData> source;
+
+  public Map<String, UserFileData> getSource() {
+    return this.source;
+  }
+
+  public void setSource(Map<String, UserFileData> source) {
+    this.source = source;
+  }
+}

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/UserProjectFileParserTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/UserProjectFileParserTest.java
@@ -1,0 +1,33 @@
+package org.code.javabuilder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class UserProjectFileParserTest {
+  private UserProjectFileParser userProjectFileParser;
+
+  @BeforeEach
+  public void setup() {
+    this.userProjectFileParser = new UserProjectFileParser();
+  }
+
+  @Test
+  public void canParseValidFileJson() throws UserFacingException, UserInitiatedException {
+    String validJson =
+        "{\"source\":{\"HelloWorld.java\":{\"text\":\"public class HelloWorld {\\n"
+            + "  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World\\\");"
+            + "\\n  }\\n}\",\"visible\":true}},\"animations\":{}}";
+    String expectedCode =
+        "public class HelloWorld {\n"
+            + "  public static void main(String[] args) {\n    System.out.println(\"Hello World\");"
+            + "\n  }\n}";
+    List<ProjectFile> files = this.userProjectFileParser.parseFileJson(validJson);
+    assertEquals(files.size(), 1);
+    ProjectFile firstFile = files.get(0);
+    assertEquals(firstFile.getFileName(), "HelloWorld.java");
+    assertEquals(firstFile.getCode(), expectedCode);
+  }
+}

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/UserProjectFileParserTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/UserProjectFileParserTest.java
@@ -1,6 +1,7 @@
 package org.code.javabuilder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,5 +30,13 @@ public class UserProjectFileParserTest {
     ProjectFile firstFile = files.get(0);
     assertEquals(firstFile.getFileName(), "HelloWorld.java");
     assertEquals(firstFile.getCode(), expectedCode);
+  }
+
+  @Test
+  public void throwsExceptionOnInvalidJson() throws UserFacingException, UserInitiatedException {
+    String invalidJson =
+        "{\"source\":{\"HelloWorld.java\":{\"text\":\"public class HelloWorld {\\n";
+    assertThrows(
+        UserFacingException.class, () -> this.userProjectFileParser.parseFileJson(invalidJson));
   }
 }


### PR DESCRIPTION
As of [this PR](https://github.com/code-dot-org/code-dot-org/pull/40049) we switched from storing Javalab code in individual java files to storing it all in `main.json` under `sources`. This PR updates our Javabuilder logic to pull and parse code from `main.json`. `main.json` is in this format:
```
{
  source: {
     'HelloWorld.java': {
         text: 'public class HelloWorld{...}',
         visible: true
     },...
  }
}
```