### PR TITLE
Support custom domain names

### DIFF
--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -18,6 +18,8 @@ def on_connect(event, context)
   region = get_region(context)
 
   request_context = event["requestContext"]
+  # Add in some logging to make debugging easier
+  puts request_context
 
   # -- Create SQS for this session --
   sqs_client = Aws::SQS::Client.new(region: region)
@@ -28,7 +30,7 @@ def on_connect(event, context)
 
   # -- Create Lambda for this session --
   lambda_client = Aws::Lambda::Client.new(region: region)
-  api_endpoint = "https://#{request_context['domainName']}/#{request_context['stage']}"
+  api_endpoint = "https://#{request_context['apiId']}.execute-api.#{region}.amazonaws.com/#{request_context['stage']}"
   payload = {
     :queueUrl => sqs_queue.queue_url,
     :apiEndpoint => api_endpoint,


### PR DESCRIPTION
Using the domain name directly in the onConnect function caused issues because a custom domain name is formatted differently than the API Gateway endpoint. In order to support direct access via the API Gateway endpoint and custom domain names, we standardized on passing the API Gateway endpoint directly to the long-running Javabuilder lambda. 

The issue was specifically with the `@connections` endpoint which produced errors like "No method found matching route staging/@connections/<connectionId> for http method POST."

This supports a change in the code-dot-org repo: https://github.com/code-dot-org/code-dot-org/pull/40189