### PR TITLE
Add support for a public websocket connectivity test

### DIFF
--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'aws-sdk-sqs'
 require 'aws-sdk-lambda'
+require 'aws-sdk-apigatewaymanagementapi'
 require 'uri'
 
 def lambda_handler(event:, context:)
@@ -21,6 +22,11 @@ def on_connect(event, context)
   # Add in some logging to make debugging easier
   puts request_context
 
+  # Return early if this is the user connectivity test
+  authorizer = request_context['authorizer']
+  if authorizer && authorizer['connectivityTest']
+    return { statusCode: 200, body: "connection successful" }
+  end
   # -- Create SQS for this session --
   sqs_client = Aws::SQS::Client.new(region: region)
   sqs_queue = sqs_client.create_queue(
@@ -30,12 +36,12 @@ def on_connect(event, context)
 
   # -- Create Lambda for this session --
   lambda_client = Aws::Lambda::Client.new(region: region)
-  api_endpoint = "https://#{request_context['apiId']}.execute-api.#{region}.amazonaws.com/#{request_context['stage']}"
+  api_endpoint = get_api_endpoint(event, context)
   payload = {
     :queueUrl => sqs_queue.queue_url,
     :apiEndpoint => api_endpoint,
     :connectionId => request_context["connectionId"],
-    :projectUrl => request_context["authorizer"]["project_url"]
+    :projectUrl => authorizer["project_url"]
   }
   response = lambda_client.invoke({
     function_name: 'javaBuilderExecuteCode:4',
@@ -54,8 +60,21 @@ def on_disconnect(event, context)
 end
 
 def on_default(event, context)
-  sqs = Aws::SQS::Client.new(region: get_region(context))
   message = event["body"]
+  # Return early if this is the user connectivity test
+  if message == 'connectivityTest'
+    client = Aws::ApiGatewayManagementApi::Client.new(
+      region: get_region(context),
+      endpoint: get_api_endpoint(event, context)
+    )
+    resp = client.post_to_connection({
+      data: "success",
+      connection_id: event["requestContext"]["connectionId"]
+    })
+    return { statusCode: 200, body: "success"}
+  end
+
+  sqs = Aws::SQS::Client.new(region: get_region(context))
   sqs.send_message(
     queue_url: get_sqs_url(event, context),
     message_body: message,
@@ -64,6 +83,11 @@ def on_default(event, context)
   )
 
   { statusCode: 200, body: "success"}
+end
+
+def get_api_endpoint(event, context)
+  request_context = event["requestContext"]
+  "https://#{request_context['apiId']}.execute-api.#{get_region(context)}.amazonaws.com/#{request_context['stage']}"
 end
 
 # ARN is of the format arn:aws:lambda:{region}:{account_id}:function:{lambda_name}

--- a/javabuilder-authorizer/lambda_function.rb
+++ b/javabuilder-authorizer/lambda_function.rb
@@ -8,6 +8,10 @@ require 'jwt'
 # and checks the token has not expired and its issue time is not in the future.
 def lambda_handler(event:, context:)
   jwt_token = event['queryStringParameters']['Authorization']
+  # Return early if this is the user connectivity test
+  if jwt_token == 'connectivityTest'
+    return generate_allow('connectivityTest', event['methodArn'], {connectivityTest: true})
+  end
   method_arn = event['methodArn']
 
   if jwt_token


### PR DESCRIPTION
This sets up a public Javabuilder endpoint for the purposes of testing a school's websocket support. The endpoint does not give access to the long-running lambda that executes code.

This supports a similar PR on the code-dot-org repo: https://github.com/code-dot-org/code-dot-org/pull/40250

Some details from a [slack conversation about this change](https://codedotorg.slack.com/archives/C03CK49G9/p1619134069451500)